### PR TITLE
add D2C Reorder Nudge Agent for subscription-free retention

### DIFF
--- a/kits/automation/reorder-nudge-agent/README.md
+++ b/kits/automation/reorder-nudge-agent/README.md
@@ -1,0 +1,42 @@
+# 🔁 D2C Reorder Nudge Agent
+
+**Built for A_Mowglies** — a pre-launch D2C disposable underwear brand.
+
+## Problem Statement
+D2C brands selling consumable/repeat-purchase products lose revenue when customers forget to reorder. There's no automated way to calculate when a customer will run out and send a personalized nudge — without a human in the loop.
+
+## What This Agent Does
+1. Takes customer purchase data as input (name, purchase date, quantity, daily usage)
+2. Calculates exactly when they'll run out of stock
+3. Generates a personalized WhatsApp reorder nudge via LLM
+4. Returns the message + reorder date instantly via API
+
+## Flow
+API Request → Code (calculates restock date) → Generate Text (LLM nudge) → API Response
+
+## Input
+```json
+{
+  "customer_name": "Priya",
+  "purchase_date": "2026-03-01",
+  "quantity": 30,
+  "daily_usage": 1
+}
+```
+
+## Output
+```json
+{
+  "message": "Hey Priya! Just a friendly reminder...",
+  "reorder_date": "Mon Mar 31 2026",
+  "days_remaining": 6
+}
+```
+
+## Built With
+- Lamatic.ai (flow builder + deployment)
+- Google Gemini 2.5 Flash
+- JavaScript (date calculation logic)
+
+## Use Case
+Applicable to any high-repeat-purchase D2C brand — disposables, supplements, pet food, skincare etc.


### PR DESCRIPTION
## Description
This PR adds the **D2C Reorder Nudge Agent**, built for **A_Mowglies** . 

The agent solves a major pain point for repeat-purchase D2C brands: **Revenue leakage due to forgotten reorders.** It automates the calculation of a customer's "stock-out" date and generates a personalized WhatsApp/SMS nudge without requiring a subscription model.

## Features
- **Stock-Out Logic:** Custom JavaScript node calculates exact replenishment dates based on `purchase_date` and `daily_usage`.
- **Personalized Outreach:** Uses LLM (Gemini) to craft friendly, brand-aligned reorder reminders.
- **API Ready:** Returns structured JSON (message, reorder date, days remaining) for easy integration with marketing tools like Klaviyo or WhatsApp APIs.

## Tech Stack
- **Framework:** Lamatic.ai
- **Model:** Google Gemini 2.5 Flash
- **Logic:** JavaScript (Date manipulation)

## Changes
- Created `d2c-reorder-nudge` example folder.
- Included `agent.json` workflow configuration.
- Added comprehensive README with sample Input/Output schemas.

## Verification
- [x] Tested with sample D2C purchase data.
- [x] Verified date calculation logic handles month-end rollovers correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Added new `kits/automation/reorder-nudge-agent/` kit with documentation
- Introduces D2C Reorder Nudge Agent for A_Mowglies brand
- Automates reorder reminders by calculating customer stock-out date based on purchase history and daily usage
- Flow: API → JavaScript date calculation → Gemini 2.5 Flash LLM nudge generation → structured JSON response
- Output includes personalized message, reorder date, and days remaining
- Targets D2C repeat-purchase brands (disposables, supplements, skincare, etc.)
- Tech stack: Lamatic.ai framework, Google Gemini 2.5 Flash, JavaScript

<!-- end of auto-generated comment: release notes by coderabbit.ai -->