### PR TITLE
feat(mou-drafter): add deploy link to lamatic.config.ts

### DIFF
--- a/kits/mou-drafter/lamatic.config.ts
+++ b/kits/mou-drafter/lamatic.config.ts
@@ -15,7 +15,7 @@ export default {
     }
   ],
   "links": {
-    "deploy": "",
+    "deploy": "https://mou.itsrohith.dev/",
     "github": "kits/mou-drafter",
   }
 };


### PR DESCRIPTION
Adding the deploy URL to the `deploy` field in `lamatic.config.ts` in mou-drafter kit as suggested by @akshatvirmani  after the original PR was merged.

Deploy link: https://mou.itsrohith.dev/

## PR Checklist

### 1. Select Contribution Type
- [ ] Kit (`kits/<category>/<kit-name>/`)
- [ ] Bundle (`bundles/<bundle-name>/`)
- [ ] Template (`templates/<template-name>/`)

---

### 2. General Requirements
- [x] PR is for **one project only** (no unrelated changes)
- [x] No secrets, API keys, or real credentials are committed
- [ ] Folder name uses `kebab-case` and matches the flow ID
- [ ] All changes are documented in `README.md` (purpose, setup, usage)

---

### 3. File Structure (Check what applies)
- [ ] `config.json` present with valid metadata (name, description, tags, steps, author, env keys)
- [ ] All flows in `flows/<flow-name>/` (where applicable) include:
  - `config.json` (Lamatic flow export)
  - `inputs.json`
  - `meta.json`
  - `README.md`
- [ ] `.env.example` with placeholder values only (kits only)
- [ ] No hand‑edited flow `config.json` node graphs (changes via Lamatic Studio export)

---

### 4. Validation
- [ ] `npm install && npm run dev` works locally (kits: UI runs; bundles/templates: flows are valid)
- [x] PR title is clear (e.g., `[kit] Add <name> for <use case>`)
- [ ] GitHub Actions workflows pass (all checks are green)
- [ ] All **CodeRabbit** or other PR review comments are addressed and resolved
- [x] No unrelated files or projects are modified