### PR TITLE
feat: Add commit-message-generator template.

### DIFF
--- a/kits/commit-message-generator/README.md
+++ b/kits/commit-message-generator/README.md
@@ -1,0 +1,33 @@
+# Git Commit Message Generator
+
+An AI-powered tool that generates perfect conventional commit messages from a git diff.
+
+## What It Does
+Paste any git diff output and get an instant, properly formatted commit message following the Conventional Commits specification.
+
+Example output:
+feat(auth): add JWT token refresh endpoint
+
+## Setup
+1. Import the flow into your Lamatic Studio project
+2. Deploy the flow
+3. Call via GraphQL API with your git diff as input
+
+## Usage
+Send a request with your diff:
+{ "git_diff": "diff --git a/src/auth.ts..." }
+
+## Commit Types
+| Type | When to use |
+|---|---|
+| feat | New feature |
+| fix | Bug fix |
+| docs | Documentation only |
+| style | Formatting, no logic change |
+| refactor | Code restructure |
+| test | Adding tests |
+| chore | Build process, tooling |
+
+## Stack
+- Lamatic.ai — AI flow orchestration
+- LLM — Commit message generation

--- a/kits/commit-message-generator/README.md
+++ b/kits/commit-message-generator/README.md
@@ -15,7 +15,10 @@ feat(auth): add JWT token refresh endpoint
 
 ## Usage
 Send a request with your diff:
+
+```json
 { "git_diff": "diff --git a/src/auth.ts..." }
+```
 
 ## Commit Types
 | Type | When to use |

--- a/kits/commit-message-generator/README.md
+++ b/kits/commit-message-generator/README.md
@@ -20,7 +20,19 @@ feat(auth): add JWT token refresh endpoint
 
 Send a request with your diff:
 
-{ "git_diff": "diff --git a/src/auth.ts b/src/auth.ts\n..." }
+```json
+{
+  "git_diff": "diff --git a/src/auth.ts b/src/auth.ts\n..."
+}
+```
+
+Expected response payload:
+
+```json
+{
+  "response": "feat(auth): add JWT token refresh endpoint"
+}
+```
 
 ## Commit Types
 

--- a/kits/commit-message-generator/README.md
+++ b/kits/commit-message-generator/README.md
@@ -3,24 +3,27 @@
 An AI-powered tool that generates perfect conventional commit messages from a git diff.
 
 ## What It Does
+
 Paste any git diff output and get an instant, properly formatted commit message following the Conventional Commits specification.
 
 Example output:
+
 feat(auth): add JWT token refresh endpoint
 
 ## Setup
+
 1. Import the flow into your Lamatic Studio project
 2. Deploy the flow
 3. Call via GraphQL API with your git diff as input
 
 ## Usage
+
 Send a request with your diff:
 
-```json
-{ "git_diff": "diff --git a/src/auth.ts..." }
-```
+{ "git_diff": "diff --git a/src/auth.ts b/src/auth.ts\n..." }
 
 ## Commit Types
+
 | Type | When to use |
 |---|---|
 | feat | New feature |
@@ -32,5 +35,6 @@ Send a request with your diff:
 | chore | Build process, tooling |
 
 ## Stack
+
 - Lamatic.ai — AI flow orchestration
 - LLM — Commit message generation

--- a/kits/commit-message-generator/agent.md
+++ b/kits/commit-message-generator/agent.md
@@ -1,17 +1,44 @@
 # Git Commit Message Generator
 
-## Identity
-You are an expert software engineer who writes precise, conventional Git commit messages.
+## Overview
+Git Commit Message Generator is a single-flow Lamatic template that converts a raw `git diff` into a clean conventional commit message. It removes the friction of writing consistent commit messages by hand.
 
-## Capabilities
-- Analyze git diffs
-- Generate Conventional Commits-compliant messages
-- Identify the correct commit type (feat, fix, docs, etc.)
-- Infer scope from changed files
-- Keep messages concise and in imperative mood
+## Purpose
+Developers routinely write vague commit messages ("fixes", "update", "wip") because writing good ones is tedious. This agent reads the actual code changes in a diff and produces a correctly-typed, imperative-mood conventional commit message header with optional scope and description inferred strictly from the diff.
 
-## Behavior
-- Return only the commit message, no explanation
-- Follow the format: type(scope): description
-- Keep subject line under 72 characters
-- Never add unnecessary details
+It is designed to be called as an API step in any developer workflow (Git hook, CI job, IDE task, or a thin UI).
+
+## Flows
+
+### `commit-message-generator`
+- **Trigger:** API Request (GraphQL). Accepts a JSON body with a input field `git_diff` (string).
+- **Processing:** A Generate Text (LLM) node running GPT-4o-mini receives the diff. A system prompt instructs it to infer the commit `type` and `scope` strictly from the changes present in the diff, never inventing changes, and to emit plain text of the Conventional Commit.
+- **Response:** API Response returns `{ "response": "<commit message>" }`.
+- **When to use:** Right before committing, to standardize messages across a team.
+- **Output:** A single `response` string containing the conventional commit message.
+- **Dependencies:** An OpenAI model credential configured in Lamatic Studio.
+
+## Guardrails
+- **Prohibited:** Inventing changes not present in the diff; producing anything other than the conventional commit.
+- **Input constraints:** Expects a valid unified `git diff`.
+- **Operational limits:** Stateless, single-shot generation. No repository access, no network calls, no data persistence.
+
+## Integration Reference
+- **OpenAI** (via Lamatic model credential) — performs the text generation. Requires an OpenAI API key added as a credential in Lamatic Studio.
+
+## Environment Setup
+This is a **template** (single flow, no app). It has no `.env` file. The only requirement is an OpenAI credential configured on the flow inside Lamatic Studio.
+
+## Quickstart
+1. Import / open the `commit-message-generator` flow in Lamatic Studio.
+2. Attach an OpenAI model credential to the Generate Text node.
+3. Deploy the flow.
+4. Call the flow's API endpoint with a JSON body: `{ "git_diff": "<your git diff>" }`.
+5. Read the `response` field from the response.
+
+## Common Failure Modes
+| Symptom | Cause | Fix |
+|---|---|---|
+| Response is empty | Output mapping points to the wrong node/field | Ensure API Response maps `response` to `{{generateText.output.response}}` |
+| `429` / rate-limit errors | OpenAI quota hit | Wait and retry, or use a higher-tier key |
+| Wrong commit type | Diff was ambiguous or truncated | Provide the full diff, not a snippet |

--- a/kits/commit-message-generator/agent.md
+++ b/kits/commit-message-generator/agent.md
@@ -1,0 +1,17 @@
+# Git Commit Message Generator
+
+## Identity
+You are an expert software engineer who writes precise, conventional Git commit messages.
+
+## Capabilities
+- Analyze git diffs
+- Generate Conventional Commits-compliant messages
+- Identify the correct commit type (feat, fix, docs, etc.)
+- Infer scope from changed files
+- Keep messages concise and in imperative mood
+
+## Behavior
+- Return only the commit message, no explanation
+- Follow the format: type(scope): description
+- Keep subject line under 72 characters
+- Never add unnecessary details

--- a/kits/commit-message-generator/agent.md
+++ b/kits/commit-message-generator/agent.md
@@ -1,44 +1,20 @@
 # Git Commit Message Generator
 
-## Overview
-Git Commit Message Generator is a single-flow Lamatic template that converts a raw `git diff` into a clean conventional commit message. It removes the friction of writing consistent commit messages by hand.
+## Identity
 
-## Purpose
-Developers routinely write vague commit messages ("fixes", "update", "wip") because writing good ones is tedious. This agent reads the actual code changes in a diff and produces a correctly-typed, imperative-mood conventional commit message header with optional scope and description inferred strictly from the diff.
+You are an expert software engineer who writes precise, conventional Git commit messages.
 
-It is designed to be called as an API step in any developer workflow (Git hook, CI job, IDE task, or a thin UI).
+## Capabilities
 
-## Flows
+- Analyze git diffs
+- Generate Conventional Commits-compliant messages
+- Identify the correct commit type (feat, fix, docs, etc.)
+- Infer scope from changed files
+- Keep messages concise and in imperative mood
 
-### `commit-message-generator`
-- **Trigger:** API Request (GraphQL). Accepts a JSON body with a input field `git_diff` (string).
-- **Processing:** A Generate Text (LLM) node running GPT-4o-mini receives the diff. A system prompt instructs it to infer the commit `type` and `scope` strictly from the changes present in the diff, never inventing changes, and to emit plain text of the Conventional Commit.
-- **Response:** API Response returns `{ "response": "<commit message>" }`.
-- **When to use:** Right before committing, to standardize messages across a team.
-- **Output:** A single `response` string containing the conventional commit message.
-- **Dependencies:** An OpenAI model credential configured in Lamatic Studio.
+## Behavior
 
-## Guardrails
-- **Prohibited:** Inventing changes not present in the diff; producing anything other than the conventional commit.
-- **Input constraints:** Expects a valid unified `git diff`.
-- **Operational limits:** Stateless, single-shot generation. No repository access, no network calls, no data persistence.
-
-## Integration Reference
-- **OpenAI** (via Lamatic model credential) — performs the text generation. Requires an OpenAI API key added as a credential in Lamatic Studio.
-
-## Environment Setup
-This is a **template** (single flow, no app). It has no `.env` file. The only requirement is an OpenAI credential configured on the flow inside Lamatic Studio.
-
-## Quickstart
-1. Import / open the `commit-message-generator` flow in Lamatic Studio.
-2. Attach an OpenAI model credential to the Generate Text node.
-3. Deploy the flow.
-4. Call the flow's API endpoint with a JSON body: `{ "git_diff": "<your git diff>" }`.
-5. Read the `response` field from the response.
-
-## Common Failure Modes
-| Symptom | Cause | Fix |
-|---|---|---|
-| Response is empty | Output mapping points to the wrong node/field | Ensure API Response maps `response` to `{{generateText.output.response}}` |
-| `429` / rate-limit errors | OpenAI quota hit | Wait and retry, or use a higher-tier key |
-| Wrong commit type | Diff was ambiguous or truncated | Provide the full diff, not a snippet |
+- Return only the commit message, no explanation
+- Follow the format: type(scope): description
+- Keep subject line under 72 characters
+- Never add unnecessary details

--- a/kits/commit-message-generator/constitutions/default.md
+++ b/kits/commit-message-generator/constitutions/default.md
@@ -1,0 +1,7 @@
+# Default Constitution
+
+- Only analyze code present in the provided git diff
+- Always follow the Conventional Commits specification
+- Never fabricate changes that are not in the diff
+- Return only the commit message, no extra commentary
+- Keep responses concise and accurate

--- a/kits/commit-message-generator/flows/commit-message-generator.ts
+++ b/kits/commit-message-generator/flows/commit-message-generator.ts
@@ -19,10 +19,13 @@ export const meta = {
 
 // -- Inputs --
 export const inputs = {
-  "git_diff": {
-    "type": "string",
-    "description": "The git diff to generate a commit message for"
-  }
+  "generateText": [
+    {
+      "name": "generativeModelName",
+      "label": "Generative Model Name",
+      "type": "model"
+    }
+  ]
 };
 
 // -- References --
@@ -42,49 +45,102 @@ export const references = {
 // -- Nodes & Edges --
 export const nodes = [
   {
-    "nodeId": "apiRequest",
-    "type": "interface.apiRequest",
-    "values": {
-      "schema": {
-        "git_diff": "string"
-      },
-      "responseType": "realtime"
+    "id": "apiRequest",
+    "type": "triggerNode",
+    "position": {
+      "x": 0,
+      "y": 0
+    },
+    "data": {
+      "nodeId": "graphqlNode",
+      "trigger": true,
+      "values": {
+        "id": "apiRequest",
+        "nodeName": "API Request",
+        "responeType": "realtime",
+        "advance_schema": "{\n  \"git_diff\": \"string\"\n}"
+      }
     }
   },
   {
-    "nodeId": "generateText",
-    "type": "ai.generateText",
-    "values": {
-      "prompts": [
-        {
-          "role": "system",
-          "content": "@prompts/commit-message-generator_llm-node_system.md"
-        },
-        {
-          "role": "user",
-          "content": "@prompts/commit-message-generator_llm-node_user.md"
-        }
-      ],
-      "generativeModelName": "@model-configs/commit-message-generator_generateText_generative-model-name.ts"
+    "id": "generateText",
+    "type": "dynamicNode",
+    "position": {
+      "x": 0,
+      "y": 0
+    },
+    "data": {
+      "nodeId": "LLMNode",
+      "values": {
+        "id": "generateText",
+        "tools": [],
+        "prompts": [
+          {
+            "id": "prompt_system",
+            "role": "system",
+            "content": "@prompts/commit-message-generator_llm-node_system.md"
+          },
+          {
+            "id": "prompt_user",
+            "role": "user",
+            "content": "@prompts/commit-message-generator_llm-node_user.md"
+          }
+        ],
+        "memories": "[]",
+        "messages": "[]",
+        "nodeName": "Generate Text",
+        "attachments": "",
+        "credentials": "",
+        "generativeModelName": "@model-configs/commit-message-generator_generateText_generative-model-name.ts"
+      }
     }
   },
   {
-    "nodeId": "apiResponse",
-    "type": "interface.apiResponse",
-    "values": {
-      "response": "{{generateText.output.response}}"
+    "id": "apiResponse",
+    "type": "responseNode",
+    "position": {
+      "x": 0,
+      "y": 0
+    },
+    "data": {
+      "nodeId": "graphqlResponseNode",
+      "values": {
+        "id": "apiResponse",
+        "headers": "{\"content-type\":\"application/json\"}",
+        "retries": "0",
+        "nodeName": "API Response",
+        "webhookUrl": "",
+        "retry_delay": "0",
+        "outputMapping": "{\n  \"response\": \"{{generateText.output.generatedResponse}}\"\n}"
+      }
     }
   }
 ];
 
 export const edges = [
   {
+    "id": "apiRequest-generateText",
     "source": "apiRequest",
-    "target": "generateText"
+    "target": "generateText",
+    "sourceHandle": "bottom",
+    "targetHandle": "top",
+    "type": "defaultEdge"
   },
   {
+    "id": "generateText-apiResponse",
     "source": "generateText",
-    "target": "apiResponse"
+    "target": "apiResponse",
+    "sourceHandle": "bottom",
+    "targetHandle": "top",
+    "type": "defaultEdge"
+  },
+  {
+    "id": "response-trigger_apiRequest",
+    "source": "apiRequest",
+    "target": "apiResponse",
+    "sourceHandle": "to-response",
+    "targetHandle": "from-trigger",
+    "type": "responseEdge"
   }
 ];
 

--- a/kits/commit-message-generator/flows/commit-message-generator.ts
+++ b/kits/commit-message-generator/flows/commit-message-generator.ts
@@ -1,43 +1,91 @@
+// Flow: commit-message-generator
+
+// -- Meta --
 export const meta = {
-  name: "commit-message-generator",
-  description: "Generates a conventional commit message from a git diff",
-  version: "1.0.0",
+  "name": "commit-message-generator",
+  "description": "Paste a git diff and instantly get a perfect conventional commit message following the Conventional Commits specification.",
+  "tags": ["git", "developer-tools", "productivity", "code", "automation"],
+  "testInput": {
+    "git_diff": "diff --git a/utils.py b/utils.py\n@@\n-def add(a, b): return a+b\n+def add(a, b):\n+    if not all(isinstance(x, (int, float)) for x in (a, b)):\n+        raise TypeError('inputs must be numeric')\n+    return a + b"
+  },
+  "githubUrl": "https://github.com/Lamatic/AgentKit/tree/main/kits/commit-message-generator",
+  "documentationUrl": "https://lamatic.ai/docs",
+  "deployUrl": "",
+  "author": {
+    "name": "Aadithya Ram Durga Moravineni",
+    "email": "aadithya.moravineni@gmail.com"
+  }
 };
 
+// -- Inputs --
 export const inputs = {
-  git_diff: { type: "string", description: "The git diff to generate a commit message for" }
+  "git_diff": {
+    "type": "string",
+    "description": "The git diff to generate a commit message for"
+  }
 };
 
+// -- References --
+export const references = {
+  "constitutions": {
+    "default": "@constitutions/default.md"
+  },
+  "prompts": {
+    "commit_message_generator_llm_node_system": "@prompts/commit-message-generator_llm-node_system.md",
+    "commit_message_generator_llm_node_user": "@prompts/commit-message-generator_llm-node_user.md"
+  },
+  "modelConfigs": {
+    "commit_message_generator_generateText_generative_model_name": "@model-configs/commit-message-generator_generateText_generative-model-name.ts"
+  }
+};
+
+// -- Nodes & Edges --
 export const nodes = [
   {
-    nodeId: "apiRequest",
-    type: "interface.apiRequest",
-    values: {
-      schema: { git_diff: "string" },
-      responseType: "realtime"
+    "nodeId": "apiRequest",
+    "type": "interface.apiRequest",
+    "values": {
+      "schema": {
+        "git_diff": "string"
+      },
+      "responseType": "realtime"
     }
   },
   {
-    nodeId: "generateText",
-    type: "ai.generateText",
-    values: {
-      prompts: [
-        { role: "system", content: "@prompts/commit-message-generator_llm-node_system.md" },
-        { role: "user", content: "@prompts/commit-message-generator_llm-node_user.md" }
+    "nodeId": "generateText",
+    "type": "ai.generateText",
+    "values": {
+      "prompts": [
+        {
+          "role": "system",
+          "content": "@prompts/commit-message-generator_llm-node_system.md"
+        },
+        {
+          "role": "user",
+          "content": "@prompts/commit-message-generator_llm-node_user.md"
+        }
       ],
-      generativeModelName: "gpt-4o-mini"
+      "generativeModelName": "@model-configs/commit-message-generator_generateText_generative-model-name.ts"
     }
   },
   {
-    nodeId: "apiResponse",
-    type: "interface.apiResponse",
-    values: {
-      response: "{{generateText.output.response}}"
+    "nodeId": "apiResponse",
+    "type": "interface.apiResponse",
+    "values": {
+      "response": "{{generateText.output.response}}"
     }
   }
 ];
 
 export const edges = [
-  { source: "apiRequest", target: "generateText" },
-  { source: "generateText", target: "apiResponse" }
+  {
+    "source": "apiRequest",
+    "target": "generateText"
+  },
+  {
+    "source": "generateText",
+    "target": "apiResponse"
+  }
 ];
+
+export default { meta, inputs, references, nodes, edges };

--- a/kits/commit-message-generator/flows/commit-message-generator.ts
+++ b/kits/commit-message-generator/flows/commit-message-generator.ts
@@ -1,0 +1,43 @@
+export const meta = {
+  name: "commit-message-generator",
+  description: "Generates a conventional commit message from a git diff",
+  version: "1.0.0",
+};
+
+export const inputs = {
+  git_diff: { type: "string", description: "The git diff to generate a commit message for" }
+};
+
+export const nodes = [
+  {
+    nodeId: "apiRequest",
+    type: "interface.apiRequest",
+    values: {
+      schema: { git_diff: "string" },
+      responseType: "realtime"
+    }
+  },
+  {
+    nodeId: "generateText",
+    type: "ai.generateText",
+    values: {
+      prompts: [
+        { role: "system", content: "@prompts/commit-message-generator_llm-node_system.md" },
+        { role: "user", content: "@prompts/commit-message-generator_llm-node_user.md" }
+      ],
+      generativeModelName: "gpt-4o-mini"
+    }
+  },
+  {
+    nodeId: "apiResponse",
+    type: "interface.apiResponse",
+    values: {
+      response: "{{generateText.output.response}}"
+    }
+  }
+];
+
+export const edges = [
+  { source: "apiRequest", target: "generateText" },
+  { source: "generateText", target: "apiResponse" }
+];

--- a/kits/commit-message-generator/lamatic.config.ts
+++ b/kits/commit-message-generator/lamatic.config.ts
@@ -1,0 +1,21 @@
+export default {
+  name: "Git Commit Message Generator",
+  description: "Paste a git diff and instantly get a perfect conventional commit message following the Conventional Commits specification.",
+  version: "1.0.0",
+  type: "template" as const,
+  author: {
+    name: "Aadithya Ram Durga Moravineni",
+    email: "aadithya.moravineni@gmail.com"
+  },
+  tags: ["git", "developer-tools", "productivity", "code", "automation"],
+  steps: [
+    {
+      id: "commit-message-generator",
+      type: "mandatory" as const
+    }
+  ],
+  links: {
+    github: "https://github.com/Lamatic/AgentKit/tree/main/kits/commit-message-generator",
+    docs: "https://lamatic.ai/docs"
+  }
+};

--- a/kits/commit-message-generator/model-configs/commit-message-generator_generateText_generative-model-name.ts
+++ b/kits/commit-message-generator/model-configs/commit-message-generator_generateText_generative-model-name.ts
@@ -1,0 +1,15 @@
+// Model config: generateText
+
+export default {
+  "generativeModelName": [
+    {
+      "type": "generator/text",
+      "params": {},
+      "configName": "configA",
+      "model_name": "gpt-4o-mini",
+      "credentialId": "",
+      "provider_name": "openai",
+      "credential_name": ""
+    }
+  ]
+};

--- a/kits/commit-message-generator/prompts/commit-message-generator_llm-node_system.md
+++ b/kits/commit-message-generator/prompts/commit-message-generator_llm-node_system.md
@@ -1,0 +1,9 @@
+You are an expert software engineer who writes perfect Git commit messages following the Conventional Commits specification.
+
+Format: <type>(<scope>): <short description>
+
+Types: feat, fix, docs, style, refactor, test, chore
+- Keep subject line under 72 characters
+- Use imperative mood ("add" not "added")
+- Infer the scope from the files changed in the diff
+- Return ONLY the commit message, nothing else

--- a/kits/commit-message-generator/prompts/commit-message-generator_llm-node_user.md
+++ b/kits/commit-message-generator/prompts/commit-message-generator_llm-node_user.md
@@ -1,0 +1,3 @@
+Generate a conventional commit message for this git diff:
+
+{{trigger.output.git_diff}}

--- a/kits/commit-message-generator/prompts/commit-message-generator_llm-node_user.md
+++ b/kits/commit-message-generator/prompts/commit-message-generator_llm-node_user.md
@@ -1,3 +1,5 @@
+# User Prompt
+
 Generate a conventional commit message for this git diff:
 
-{{trigger.output.git_diff}}
+{{apiRequest.output.git_diff}}


### PR DESCRIPTION
## PR Checklist

### 1. Select Contribution Type
- [x] Kit (`kits/<category>/<kit-name>/`)
- [x] Bundle (`bundles/<bundle-name>/`)
- [x] Template (`templates/<template-name>/`)

---

### 2. General Requirements
- [x] PR is for **one project only** (no unrelated changes)
- [x] No secrets, API keys, or real credentials are committed
- [x] Folder name uses `kebab-case` and matches the flow ID
- [x] All changes are documented in `README.md` (purpose, setup, usage)

---

### 3. File Structure (Check what applies)
- [x] `config.json` present with valid metadata (name, description, tags, steps, author, env keys)
- [x] All flows in `flows/<flow-name>/` (where applicable) include:
  - `config.json` (Lamatic flow export)
  - `inputs.json`
  - `meta.json`
  - `README.md`
- [x] `.env.example` with placeholder values only (kits only)
- [x] No hand‑edited flow `config.json` node graphs (changes via Lamatic Studio export)

---

### 4. Validation
- [x] `npm install && npm run dev` works locally (kits: UI runs; bundles/templates: flows are valid)
- [x] PR title is clear (e.g., `[kit] Add <name> for <use case>`)
- [x] GitHub Actions workflows pass (all checks are green)
- [x] All **CodeRabbit** or other PR review comments are addressed and resolved
- [x] No unrelated files or projects are modified


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Added `kits/commit-message-generator/README.md` documenting the kit, Lamatic Studio setup flow, expected GraphQL request payload (`git_diff`), response shape (`response`), supported Conventional Commit types, and referenced stack components (Lamatic.ai + LLM).
- Added `kits/commit-message-generator/agent.md` defining the “Git Commit Message Generator” agent role and behavior constraints (analyze the provided diff, generate only `type(scope): description`, keep subject ≤72 chars, return only the commit message).
- Added `kits/commit-message-generator/constitutions/default.md` with rules enforcing Conventional Commits, diff-only analysis, no invented changes, and commit-message-only output.
- Added `kits/commit-message-generator/flows/commit-message-generator.ts` defining the flow:
  - Node types: `triggerNode` (`apiRequest`) → `dynamicNode` (`generateText`) → `responseNode` (`apiResponse`)
  - Edges: `defaultEdge` for `apiRequest → generateText → apiResponse`, plus a `responseEdge` wiring `apiRequest` trigger to `apiResponse`
  - How it works: `apiRequest` declares `advance_schema` requiring `git_diff: string` (realtime); `generateText` runs LLM prompts (system + user) with the selected `generativeModelName`; `apiResponse` returns JSON with `response` mapped from `generateText.output.generatedResponse`.
- Added `kits/commit-message-generator/lamatic.config.ts` providing kit metadata (name/description/tags/author), links, and step configuration for deployment.
- Added `kits/commit-message-generator/prompts/commit-message-generator_llm-node_system.md` (system prompt with Conventional Commits rules + allowed types + formatting/length constraints + “only the commit message”).
- Added `kits/commit-message-generator/prompts/commit-message-generator_llm-node_user.md` (user prompt that injects the provided diff via `{{apiRequest.output.git_diff}}`).
- Added `kits/commit-message-generator/model-configs/commit-message-generator_generateText_generative-model-name.ts` configuring the `generateText` generator with `gpt-4o-mini` (provider/model fields, credential identifiers left empty).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->