### PR TITLE
feat: Add incident postmortem pipeline

### DIFF
--- a/kits/incident-postmortem-pipeline/apps/next-env.d.ts
+++ b/kits/incident-postmortem-pipeline/apps/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/kits/incident-postmortem-pipeline/flows/incident-postmortem-pipeline.ts
+++ b/kits/incident-postmortem-pipeline/flows/incident-postmortem-pipeline.ts
@@ -95,7 +95,7 @@ export const nodes = [
       "values": {
         "id": "triggerNode_1",
         "nodeName": "API Request",
-        "responeType": "realtime",
+          "responseType": "realtime",
         "advance_schema": "{\n  \"logs\": \"string\",\n  \"serviceName\": \"string\",\n  \"recentDeployTime\": \"string\"\n}"
       }
     }

--- a/kits/incident-postmortem-pipeline/prompts/incident-postmortem-pipeline_llmnode-5_system_0.md
+++ b/kits/incident-postmortem-pipeline/prompts/incident-postmortem-pipeline_llmnode-5_system_0.md
@@ -4,7 +4,7 @@ You are a postmortem author. Assemble the provided inputs into a structured mark
 ## Summary
 {stakeholder summary}
 ## Timeline
-{derive from log extractor timeWindow and notableEvents}
+{derive from the extracted log data and only include events explicitly supported by that data}
 ## Root Cause Analysis
 {ranked hypotheses with Evidence-based/Inferred/Unknown tags preserved verbatim}
 ## Mitigation Steps Taken

--- a/kits/incident-postmortem-pipeline/prompts/incident-postmortem-pipeline_llmnode-5_user_1.md
+++ b/kits/incident-postmortem-pipeline/prompts/incident-postmortem-pipeline_llmnode-5_user_1.md
@@ -1,4 +1,5 @@
 Assemble a final incident postmortem document in markdown, combining the sections below. Preserve the Evidence-based / Inferred / Unknown tags from the root cause section exactly as written.
+Extracted Log Data: {{LLMNode_1.output.generatedResponse}}
 Root Cause Hypotheses:{{LLMNode_2.output.generatedResponse}}
 Mitigation Checklist:{{LLMNode_3.output.generatedResponse}}
 Stakeholder Summary:{{LLMNode_4.output.generatedResponse}}


### PR DESCRIPTION
## Summary
Adds the Incident Postmortem Pipeline kit, which turns raw incident logs into a structured, evidence-graded postmortem.

## What’s Included
- A Next.js app for pasting raw incident logs and viewing the generated postmortem
- A Lamatic flow that extracts log signals, ranks root-cause hypotheses, generates mitigation steps, and assembles the final report
- Externalized prompts and model configs via `@reference` files

## Validation
- Verified the touched flow and prompt files for syntax issues
- Pushed the fixes to the `fix-incident-postmortem` branch

## Notes
This PR resubmits the reverted kit after addressing review feedback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Adds the Incident Postmortem Pipeline kit, including:
  - A Next.js app for submitting incident logs and viewing generated postmortems.
  - Externalized prompt and model configuration files using `@reference`.
  - A Lamatic flow that extracts log signals, evaluates root-cause hypotheses, generates mitigation steps, and assembles an evidence-graded report.
- Updates the flow trigger schema to use the correct `responseType` property.
- Updates Next.js route type references for development builds.
- Improves postmortem prompts by:
  - Restricting timeline events to those explicitly supported by extracted log data.
  - Including extracted log data in the final report.
- Includes syntax-validated flow and prompt files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->