### PR TITLE
fix: migrate ChangeGraph from deprecated Llama 3.3 model 

### DIFF
--- a/kits/changegraph-release-intelligence/model-configs/analyze-change-impact_instructor-llmnode-356-copy-979_generative-model-name.ts
+++ b/kits/changegraph-release-intelligence/model-configs/analyze-change-impact_instructor-llmnode-356-copy-979_generative-model-name.ts
@@ -10,7 +10,7 @@ export default {
         "temperature": 0.2
       },
       "configName": "configA",
-      "model_name": "groq/llama-3.3-70b-versatile",
+      "model_name": "groq/openai/gpt-oss-120b",
       "credentialId": "387bab0c-d0ed-4d69-9733-23e7accb1a3b",
       "provider_name": "groq",
       "credential_name": "api2"

--- a/kits/changegraph-release-intelligence/model-configs/generate-release-plan_instructor-llmnode-863_generative-model-name.ts
+++ b/kits/changegraph-release-intelligence/model-configs/generate-release-plan_instructor-llmnode-863_generative-model-name.ts
@@ -10,7 +10,7 @@ export default {
         "temperature": 0.1
       },
       "configName": "configA",
-      "model_name": "groq/llama-3.3-70b-versatile",
+      "model_name": "groq/openai/gpt-oss-120b",
       "credentialId": "387bab0c-d0ed-4d69-9733-23e7accb1a3b",
       "provider_name": "groq",
       "credential_name": "api2"


### PR DESCRIPTION
# PR Description

## Summary

Migrates ChangeGraph from the deprecated `llama-3.3-70b-versatile` model to `openai/gpt-oss-120b` on Groq.

## Changes

* Updated the model configuration for `analyze-change-impact`
* Updated the model configuration for `generate-release-plan`
* Kept the Groq provider and existing flow configuration unchanged
* No changes were made to prompts, schemas, deterministic risk scoring, blast-radius calculation, or application logic

## Validation

Both Lamatic flows were updated, redeployed, and tested successfully with the new model before updating the repository configuration.

This change keeps ChangeGraph functional after the previous model's deprecation while preserving the existing release-safety architecture.
