### PR TITLE
fix: use unquoted-key style in google-drive-template lamatic.config.ts

### DIFF
--- a/kits/google-drive-template/lamatic.config.ts
+++ b/kits/google-drive-template/lamatic.config.ts
@@ -1,21 +1,18 @@
 export default {
-  "name": "Google Drive Template",
-  "description": "Syncs files from a Google Drive folder, chunks and embeds their content, and indexes the vectors into a vector database to power a continuously updated RAG knowledge base.",
-  "version": "1.0.0",
-  "type": "template",
-  "author": {
-    "name": "Akshat Virmani",
-    "email": "akshatv@lamatic.ai"
+  name: "Google Drive Template",
+  description: "Syncs files from a Google Drive folder, chunks and embeds their content, and indexes the vectors into a vector database to power a continuously updated RAG knowledge base.",
+  version: "1.0.0",
+  type: "template" as const,
+  author: {
+    name: "Akshat Virmani",
+    email: "akshatv@lamatic.ai"
   },
-  "tags": ["google-drive", "rag", "vector-database", "embeddings", "indexing"],
-  "steps": [
-    {
-      "id": "fr1",
-      "type": "mandatory"
-    }
+  tags: ["google-drive", "rag", "vector-database", "embeddings", "indexing"],
+  steps: [
+    { id: "fr1", type: "mandatory" as const }
   ],
-  "links": {
-    "deploy": "https://studio.lamatic.ai/template/google-drive-template",
-    "github": "https://github.com/Lamatic/AgentKit/tree/main/kits/google-drive-template"
+  links: {
+    deploy: "https://studio.lamatic.ai/template/google-drive-template",
+    github: "https://github.com/Lamatic/AgentKit/tree/main/kits/google-drive-template"
   }
 };


### PR DESCRIPTION
## Summary
- `kits/google-drive-template/lamatic.config.ts` used quoted JSON-style keys (`"name": "..."`) instead of the unquoted TS-object style every other kit uses.
- The `update-registry.yml` regex parser expects unquoted keys immediately followed by `:` — the quoted style caused `name`, `description`, `tags`, `author`, `steps`, and `links` to all silently fail to parse, leaving the catalog entry blank (name falling back to the raw slug).
- Verified by extracting the workflow's actual embedded parser script and running it locally against both the old and new file — old style: every field blank; new style: everything parses correctly.

## Test plan
- [x] Ran the CI's own `update-registry.mjs` script locally against the fixed config and confirmed `name`, `description`, `tags`, `author`, `steps`, and `links` all parse correctly.
- [ ] After merge, re-run `update-registry.yml` (`workflow_dispatch` with `kits: kits/google-drive-template`) to refresh the live `registry.json` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)